### PR TITLE
Fix python 3 compatibility

### DIFF
--- a/data.py
+++ b/data.py
@@ -22,7 +22,7 @@ def read_data(fname, count, word2idx):
         word2idx['<eos>'] = 0
 
     for word, _ in count:
-        if not word2idx.has_key(word):
+        if word not in word2idx:
             word2idx[word] = len(word2idx)
 
     data = list()

--- a/model.py
+++ b/model.py
@@ -3,6 +3,7 @@ import math
 import random
 import numpy as np
 import tensorflow as tf
+from past.builtins import xrange
 
 class MemN2N(object):
     def __init__(self, config, sess):


### PR DESCRIPTION
In python 3
- dictionary doesn't have attribute has_key()
- xrange is deprecated

One needs to install 'future' package to use xrange in python 3 with
`pip install future`
`from past.builtins import xrange`
